### PR TITLE
feat: add template for credit page (#46)

### DIFF
--- a/layouts/credit/single.html
+++ b/layouts/credit/single.html
@@ -1,0 +1,32 @@
+{{ define "main" }}
+<div class="container page" data-pagefind-body>
+    <hgroup>
+        <h1>{{ .Title }}</h1>
+        {{ with .GetTerms "roles" }}
+        <p>
+            {{ partial "inline-list.html" . }}
+        </p>
+        {{ end }}
+    </hgroup>
+
+    {{ with .GetTerms "artists" }}
+    <hgroup>
+        <h2>Artist</h2>
+        {{ range . }}
+        <p><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>
+        {{ end }}
+    </hgroup>
+    {{ end }}
+
+    {{ with .GetTerms "locations" }}
+    <hgroup>
+        <h2>Location</h2>
+        {{ range . }}
+        <p><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>
+        {{ end }}
+    </hgroup>
+    {{ end }}
+
+    {{ .Content }}
+</div>
+{{ end }}

--- a/layouts/partials/credits.html
+++ b/layouts/partials/credits.html
@@ -13,6 +13,7 @@
     at
     {{ end -}}
     {{ partial "inline-list.html" $locations }}
+    <a href="{{ .RelPermalink }}">(details)</a>
 </li>
 {{- end -}}
 </ul>


### PR DESCRIPTION
Added a template for credit pages. Will separately deal with ignoring them from the search results.

Resovles #46 