### PR TITLE
feat(theme): make mastodon url configurable (#74)

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,5 +1,6 @@
 description = "Music, Software, Midwest"
 profile_image = "images/profile-large.png"
+mastodon_url = "https://mastodon.social/@themizzi"
 
 # Author information for RSS
 [author]

--- a/themes/mizzi/README.md
+++ b/themes/mizzi/README.md
@@ -27,6 +27,19 @@ profile_image = "images/profile.png"    # Hugo will resize this as needed (minim
 
 If this parameter is not set or the image doesn't exist, the theme will automatically use placeholder images.
 
+### Mastodon Verification
+
+The theme supports Mastodon verification via the `rel="me"` link attribute:
+
+```toml
+# config/_default/params.toml
+
+# Mastodon verification link (optional)
+mastodon_url = "https://mastodon.social/@yourusername"
+```
+
+If this parameter is not set, no Mastodon verification link will be included.
+
 ### Profile Image Setup
 
 1. Place your profile image in your site's `assets/images/` directory (minimum 400x400px recommended)

--- a/themes/mizzi/exampleSite/config/_default/params.toml
+++ b/themes/mizzi/exampleSite/config/_default/params.toml
@@ -3,6 +3,9 @@ description = "Example site using the Mizzi Hugo theme - perfect for musicians a
 # Profile image (optional - will fall back to placeholder if not provided)
 # profile_image = "images/profile.png"    # Hugo will resize as needed (minimum 400x400px recommended)
 
+# Mastodon verification link (optional)
+mastodon_url = "https://mastodon.social/@Mastodon"
+
 # Optional: Custom bucket/CDN address for assets
 # bucket_address = "https://cdn.yoursite.com"
 

--- a/themes/mizzi/layouts/partials/head.html
+++ b/themes/mizzi/layouts/partials/head.html
@@ -84,7 +84,9 @@
 
 {{- /* Additional Meta Tags */}}
 <link rel="manifest" href="/site.webmanifest">
-<link rel="me" href="https://mastodon.social/@themizzi">
+{{- with .Site.Params.mastodon_url -}}
+<link rel="me" href="{{ . }}">
+{{- end -}}
 
 {{- /* JSON-LD Structured Data for RSS Discovery */}}
 {{- if .IsHome -}}


### PR DESCRIPTION
Resolves #74 

This pull request introduces Mastodon verification support to the Mizzi Hugo theme by adding a `mastodon_url` configuration parameter. It includes updates to documentation, example configurations, layout templates, and automated tests to ensure proper functionality.

### Mastodon Verification Feature:

* **Configuration Parameter**: Added a new optional `mastodon_url` parameter to `config/_default/params.toml` for specifying a Mastodon profile link. [[1]](diffhunk://#diff-00150d767f2627e231300ea0ce78bc60805c696cb28e4ea0c6c505b09afe0608R3) [[2]](diffhunk://#diff-abbc034965e08aa49cfb40fa0814b945e7caa65a1060dae0cd67e20c5d5be0e0R6-R8)
* **Documentation Updates**: Updated `themes/mizzi/README.md` to include instructions for configuring Mastodon verification via the `mastodon_url` parameter.
* **Template Logic**: Modified `themes/mizzi/layouts/partials/head.html` to dynamically include a `<link rel="me">` tag for Mastodon verification based on the `mastodon_url` parameter.

### Automated Tests:

* **Test Coverage**: Added tests in `themes/mizzi/tests/build.test.ts` to verify the presence or absence of the Mastodon `rel="me"` link based on the configuration of the `mastodon_url` parameter.