### PR TITLE
ci: remove github environment during pr teardown (#84)

### DIFF
--- a/.github/workflows/pr-teardown.yaml
+++ b/.github/workflows/pr-teardown.yaml
@@ -4,6 +4,13 @@ on:
 # Run on all closed PRs
   pull_request:
     types: [ closed ]
+  # Temporary: Allow manual testing
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to test cleanup for'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -28,7 +35,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const prNumber = context.payload.pull_request.number;
+            const prNumber = context.payload.pull_request?.number || context.payload.inputs?.pr_number;
             const environment = `pr-${prNumber}`;
             
             // Get all deployments for this repository
@@ -54,5 +61,28 @@ jobs:
                 console.log(`Marked deployment ${deployment.id} as inactive`);
               } catch (error) {
                 console.log(`Failed to mark deployment ${deployment.id} as inactive: ${error.message}`);
+              }
+            }
+
+      - name: Delete GitHub environment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request?.number || context.payload.inputs?.pr_number;
+            const environment = `pr-${prNumber}`;
+            
+            try {
+              await github.rest.repos.deleteAnEnvironment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment_name: environment
+              });
+              console.log(`Successfully deleted environment: ${environment}`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`Environment ${environment} not found - may have already been deleted`);
+              } else {
+                console.log(`Failed to delete environment ${environment}: ${error.message}`);
               }
             }


### PR DESCRIPTION
Resolves #84 

This pull request updates the `pr-teardown.yaml` workflow to support manual testing and enhance cleanup functionality by allowing deletion of GitHub environments. The changes primarily focus on adding manual triggers and improving the script logic for handling pull request numbers and environment cleanup.

### Enhancements to workflow triggers:
* [`.github/workflows/pr-teardown.yaml`](diffhunk://#diff-47ce08c7da515832db4d3fe0900a2434186f2c1bc47b1b5455e316e2da2ea1e0R7-R13): Added `workflow_dispatch` to enable manual testing with an input for specifying the PR number.

### Improvements to cleanup logic:
* [`.github/workflows/pr-teardown.yaml`](diffhunk://#diff-47ce08c7da515832db4d3fe0900a2434186f2c1bc47b1b5455e316e2da2ea1e0L31-R38): Updated the script to handle pull request numbers from both `pull_request` and `workflow_dispatch` events, ensuring compatibility with manual testing.
* [`.github/workflows/pr-teardown.yaml`](diffhunk://#diff-47ce08c7da515832db4d3fe0900a2434186f2c1bc47b1b5455e316e2da2ea1e0R66-R88): Added a new step to delete the associated GitHub environment for the PR, with error handling for cases where the environment might already be deleted or not found.