### PR TITLE
ci: use pre-built image when deploying to DO

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,10 +50,3 @@ VOLUME [ "/home/node/.zsh" ]
 EXPOSE 1313
 
 USER node
-
-FROM dev AS build
-
-COPY --chown=node:node ./ /workspace
-WORKDIR /workspace
-
-RUN make build

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -6,8 +6,12 @@ static_sites:
     deploy_on_push: true
   name: site
   source_dir: /
-  dockerfile_path: /.devcontainer/Dockerfile
+  dockerfile_path: ./Dockerfile
   output_dir: /workspace/public
+  envs:
+  - key: IMAGE_TAG
+    value: ${IMAGE_TAG}
+    scope: BUILD_TIME
 domains:
 - domain: joemizzi.com
   type: PRIMARY

--- a/.github/actions/deploy-app/action.yml
+++ b/.github/actions/deploy-app/action.yml
@@ -20,6 +20,10 @@ inputs:
   environment:
     description: 'Deployment environment name'
     required: false
+  image-tag:
+    description: 'Docker image tag to use for deployment'
+    required: false
+    default: 'latest'
 
 runs:
   using: 'composite'
@@ -36,6 +40,8 @@ runs:
     - name: Deploy the app
       id: deploy
       uses: digitalocean/app_action/deploy@v2
+      env:
+        IMAGE_TAG: ${{ inputs.image-tag }}
       with:
         token: ${{ inputs.token }}
         project_id: ${{ inputs.app-id }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: ./.github/actions/deploy-app
         with:
           token: ${{ secrets.DIGITAL_OCEAN_ACCESS_TOKEN }}
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ env.APP_ID }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment.outputs.deployment-id }}
           environment: 'production'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,8 +56,9 @@ jobs:
         uses: ./.github/actions/deploy-app
         with:
           token: ${{ secrets.DIGITAL_OCEAN_ACCESS_TOKEN }}
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ env.APP_ID }}
           deploy-pr-preview: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deployment-id: ${{ steps.deployment.outputs.deployment-id }}
-          environment: 'pr-${{ github.event.pull_request.number }}' 
+          environment: 'pr-${{ github.event.pull_request.number }}'
+          image-tag: 'pr-${{ github.event.pull_request.number }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+ARG IMAGE_TAG=${IMAGE_TAG:-latest}
+FROM ghcr.io/themizzi/themizzi.github.io/devcontainer:${IMAGE_TAG} AS source
+COPY --chown=node:node ./ /workspace
+WORKDIR /workspace
+RUN make build


### PR DESCRIPTION
Resolves #70 

This pull request introduces support for dynamic Docker image tagging across the deployment pipeline. The changes ensure that specific image tags can be passed and utilized during builds and deployments, improving flexibility and traceability.

### Enhancements to Docker image tagging:

* [`.do/app.yaml`](diffhunk://#diff-0bb97e03774b3456869a76ea9fe3dc9a77382f542969cf7ee0138573a8b4aba5R11-R14): Added an `envs` section to define the `IMAGE_TAG` environment variable with a default value of `latest` and a scope of `BUILD_TIME`.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R2): Introduced an `ARG IMAGE_TAG` with a default value of `latest` and updated the `FROM` directive to use the `IMAGE_TAG` argument dynamically.

### Updates to GitHub Actions:

* [`.github/actions/deploy-app/action.yml`](diffhunk://#diff-6d02669639c34728e4da5da949e4a6c805f98e36a84e117950c4b394090e7457R23-R26): Added a new input `image-tag` for specifying the Docker image tag during deployment, with a default value of `latest`. Updated the `env` section in the `runs` block to pass the `IMAGE_TAG` environment variable using this input. [[1]](diffhunk://#diff-6d02669639c34728e4da5da949e4a6c805f98e36a84e117950c4b394090e7457R23-R26) [[2]](diffhunk://#diff-6d02669639c34728e4da5da949e4a6c805f98e36a84e117950c4b394090e7457R43-R44)
* [`.github/workflows/pr.yaml`](diffhunk://#diff-1eb4e5fd5611777d4e597ef299a1cb5ba8050c28a2dabbd4fbc56205d69e5ddaR64): Enhanced the pull request workflow by passing a dynamically generated `image-tag` based on the pull request number (`pr-${{ github.event.pull_request.number }}`).